### PR TITLE
Fix/incorrect error

### DIFF
--- a/test/Funnel.t.sol
+++ b/test/Funnel.t.sol
@@ -100,7 +100,7 @@ contract FunnelTest is ERC5827TestSuite {
         assertEq(funnel.allowance(user1, address(spender)), 0);
 
         vm.prank(user2);
-        vm.expectRevert();
+        vm.expectRevert("ERC20: insufficient allowance");
         funnel.transferFromAndCall(user1, address(spender), 10, "");
     }
 

--- a/test/Funnel.t.sol
+++ b/test/Funnel.t.sol
@@ -90,6 +90,20 @@ contract FunnelTest is ERC5827TestSuite {
         assertTrue(funnel.transferFromAndCall(user1, address(spender), 10, ""));
     }
 
+    function testInsufficientBaseAllowance() public {
+        vm.prank(user1);
+        token.approve(address(funnel), 0);
+
+        vm.prank(user1);
+        funnel.approveRenewable(user2, 1337, 1);
+
+        assertEq(funnel.allowance(user1, address(spender)), 0);
+
+        vm.prank(user2);
+        vm.expectRevert();
+        funnel.transferFromAndCall(user1, address(spender), 10, "");
+    }
+
     function testOverflow() public {
         vm.prank(user1);
         funnel.approveRenewable(address(user2), type(uint256).max - type(uint192).max + 1, type(uint192).max);


### PR DESCRIPTION
Addresses #59 
No longer checks baseToken on transferFrom, only within allowance()

Gas improvement
```javascript
testNoCodeTokenReverts() (gas: 0 (0.000%)) 
testSupportInterfaceReceiver() (gas: 0 (0.000%)) 
testSupportInterfaceSpender() (gas: 0 (0.000%)) 
testFailExecuteMetaTransactionReplayProtection() (gas: 3 (0.002%)) 
testExecuteMetaTransactionApproveRenewable() (gas: 3 (0.002%)) 
testPermit() (gas: 3 (0.002%)) 
testApproveRenewable() (gas: 3 (0.003%)) 
testRenewableMaxAllowance() (gas: 6 (0.006%)) 
testApproveFuzzing(uint256) (gas: 9 (0.008%)) 
testInitialAllowance() (gas: 3 (0.012%)) 
testRecoveryRateCasting() (gas: -22 (-0.026%)) 
testBaseTokenAllowance() (gas: 69 (0.066%)) 
testPermitRenewable() (gas: 113 (0.086%)) 
testFailPermitRenewablePastDeadline() (gas: -22 (-0.110%)) 
testTransfer() (gas: 120 (0.194%)) 
testSupportsInterfacePayable() (gas: -22 (-0.377%)) 
testApproveWithTransferFuzzing(uint256,uint256) (gas: -1376 (-0.913%)) 
testApprove() (gas: -1335 (-0.922%)) 
testTransferFromFunnel() (gas: -2770 (-0.941%)) 
testApproveMaxWithTransfer() (gas: -1379 (-0.994%)) 
testTransferFromAndCall() (gas: -1385 (-0.998%)) 
testInfiniteApproveTransferFrom() (gas: -1341 (-1.000%)) 
testOverflow3() (gas: -1385 (-1.066%)) 
testOverflow2() (gas: -1385 (-1.188%)) 
testOverflow() (gas: -1385 (-1.188%)) 
testTransferFromAndCallRevertNonContract() (gas: -1385 (-1.221%)) 
testTransferFromAndCallRevertNonReceiver() (gas: -1385 (-1.238%)) 
testFailApprovewithTransferInsufficientBalance() (gas: -1382 (-1.275%)) 
testFailApproveWithTransferInsufficientApproval() (gas: -1382 (-1.375%)) 
testClearRenewableAllowanceOnNormalApprove() (gas: -2617 (-1.793%)) 
testRenewableAllowanceTransferFrom() (gas: -5550 (-3.573%)) 
testInsufficientAllowance() (gas: -7907 (-26.902%)) 
Overall gas change: -35083 (-46.720%)

```